### PR TITLE
Fix issue with inconsistent output due to ts-node/register not being …

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {
-    "test": "nyc mocha test/integration/**/*.spec.ts",
+    "test": "nyc --require ts-node/register mocha test/integration/**/*.spec.ts",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "system-test": "mocha -r ts-node/register test/system/**/*.spec.ts",
     "lint": "tslint {source,test}/**/*.ts",
@@ -27,6 +27,7 @@
       "html",
       "text"
     ],
+    "sourceMap": true,
     "all": true
   },
   "repository": {

--- a/test/integration/provision.spec.ts
+++ b/test/integration/provision.spec.ts
@@ -1,0 +1,27 @@
+import * as chai from 'chai';
+import { main as mainProvision } from '../../source/provision';
+import { main as mainDeprovision } from '../../source/deprovision';
+import * as util from 'util';
+
+const provisionTables = util.promisify(mainProvision);
+const deprovisionTables = util.promisify(mainDeprovision);
+
+const expect = chai.expect;
+
+describe('dynamo-provision', () => {
+
+    after(async () => {
+        const result = await deprovisionTables({}, null);
+    });
+
+    it('should return Success when provisioning tables that do not yet exist', async () => {
+        const result = await provisionTables({}, null);
+        expect(result.statusCode).to.be.equal(200);
+    });
+
+    it('should return Success when deprovisioning tables that exist in DynamoDB', async () => {
+        await provisionTables({}, null);
+        const result = await deprovisionTables({}, null);
+        expect(result.statusCode).to.be.equal(200);
+    });
+});


### PR DESCRIPTION
…passed to nyc (see https://github.com/istanbuljs/nyc/issues/849); increase code coverage